### PR TITLE
Add ability to return current log level of logger-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ $ gogo-set-log-level com.mycompany.mylogger DEBUG
 
 ```
 
+If <log-level> is not set the current level of <logger-name> is returned.
+
+Example:
+
+```
+$ gogo-set-log-level com.mycompany 
+Level for com.mycompany: ERROR
+```
+
 #### gogo-reindex-all-search-indexes
 
 Reindex all search indexes.

--- a/gogo-set-log-level
+++ b/gogo-set-log-level
@@ -26,9 +26,10 @@
 # Further documentation: https://github.com/slemarchand/liferay-gogo-scripts
 #
 
-if { $argc < 2 } {
+if { $argc < 1 } {
 	set command [file tail $argv0]
 	send_user "usage: $command <logger-name> <log-level>\n"
+	send_user "If <log-level> is not set the current level of <logger-name> is returned.\n"
 	exit 1
 }
 
@@ -69,7 +70,19 @@ set level [lindex $argv 1];
 
 set groovy_script " \
 	import static com.liferay.util.log4j.Log4JUtil.setLevel; \
-	setLevel('$name','$level',true); \
+        import static com.liferay.util.log4j.Log4JUtil.getOriginalLevel; \
+	level = '$level'; \
+	name = '$name'; \
+        if(!level.isEmpty()) { \
+	    setLevel(name, level, true); \
+ 	    println('Level set'); \
+        } else { \
+  	    try { \
+           	println('Level for ' + name + ': ' + getOriginalLevel(name)); \
+            } catch(java.lang.Exception ex) { \
+        	ex.printStackTrace(); \
+            } \
+ 	} \
 ";
 
 send -- " \


### PR DESCRIPTION
Simply put, `gogo-set-log-level` returns current log level of logger-name if log-level is not passed as argument. Updated instructions in README.md